### PR TITLE
Fix chatgpt llm memory

### DIFF
--- a/your_assistant/core/orchestrator.py
+++ b/your_assistant/core/orchestrator.py
@@ -161,7 +161,6 @@ class ChatGPTOrchestrator(LLMOrchestrator):
         """
         if len(args.prompt) == 0:
             return ""
-        args.use_memory = False
         if not self.llm:
             raise ValueError("The llm must be initialized.")
         messsage = [HumanMessage(content=args.prompt)]


### PR DESCRIPTION
## Summary
I thought langchain ChatOpenAI has memory by default, so I disabled the customized memory. Now add it back.

## Test Plan

<img width="1073" alt="Screenshot 2023-04-10 at 9 25 19 PM" src="https://user-images.githubusercontent.com/2237303/231055894-359827ea-0a1b-47eb-80a8-b73a34b8d9dc.png">
